### PR TITLE
Fix game abandonment and reconnection issues

### DIFF
--- a/src/components/game/GameModeSelection.tsx
+++ b/src/components/game/GameModeSelection.tsx
@@ -57,8 +57,18 @@ export default function GameModeSelection({ onModeSelect }: GameModeSelectionPro
     }
   };
 
-  const handleConfirmNewGame = () => {
+  const handleConfirmNewGame = async () => {
     setShowConfirmDialog(false);
+    
+    // Abandon the current game before creating a new one
+    if (user?.playerId) {
+      try {
+        await onlineGameService.leaveAllMatches(user.playerId);
+      } catch (error) {
+        console.error('Error abandoning current game:', error);
+      }
+    }
+    
     setActiveGame(null); // Clear activeGame to avoid stale state
     onModeSelect(GameMode.ONLINE);
   };


### PR DESCRIPTION
## Summary
- Fixed game abandonment to only occur when explicitly creating/joining new games
- Fixed WebSocket reconnection issues showing empty board
- Added abandon warning for Join with Code flow

## Changes
- Games are now only marked as ABANDONED when player clicks "Abandon & Start New" or "Abandon & Join"
- Removed automatic game abandonment when navigating away from game
- Fixed WebSocket disconnect timing issue that caused empty boards on reconnection
- Added consistent abandon warnings for both Create Game and Join with Code flows

## Test plan
- [ ] Create a game and navigate back to menu - game should stay IN_PROGRESS
- [ ] Click "Reconnect to Game" - board should show with correct state
- [ ] With active game, click "Create Game" - should see abandon warning
- [ ] With active game, click "Join with Code" - should see abandon warning
- [ ] Confirm abandon - old game should be marked ABANDONED in database
- [ ] Cancel abandon - should stay on current screen