### PR TITLE
Disable Local Duel mode temporarily

### DIFF
--- a/src/components/game/GameModeSelection.tsx
+++ b/src/components/game/GameModeSelection.tsx
@@ -268,13 +268,12 @@ export default function GameModeSelection({ onModeSelect }: GameModeSelectionPro
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {/* Local Mode */}
           <Card 
-            className="cursor-pointer hover:shadow-2xl transition-all duration-300 hover:scale-105 bg-gradient-to-br from-blue-800/50 to-purple-800/50 backdrop-blur-md border-blue-500/50 hover:border-blue-400 hover:shadow-blue-500/20 group"
-            onClick={handleLocalMode}
+            className="cursor-not-allowed opacity-75 bg-gradient-to-br from-gray-800/50 to-gray-700/50 backdrop-blur-md border-gray-600/50 group"
           >
             <CardHeader className="pb-4">
               <div className="flex items-center justify-center mb-4 relative">
-                <div className="absolute inset-0 bg-blue-500/20 rounded-full blur-2xl group-hover:bg-blue-500/30 transition-all duration-300" />
-                <Users className="w-20 h-20 text-blue-400 relative z-10 group-hover:scale-110 transition-transform duration-300" />
+                <div className="absolute inset-0 bg-blue-500/20 rounded-full blur-2xl" />
+                <Users className="w-20 h-20 text-blue-400 relative z-10" />
               </div>
               <CardTitle className="text-2xl text-center bg-gradient-to-r from-blue-300 to-blue-100 bg-clip-text text-transparent">
                 Local Duel
@@ -299,8 +298,8 @@ export default function GameModeSelection({ onModeSelect }: GameModeSelectionPro
                 </div>
               </div>
               <div className="mt-6 text-center">
-                <span className="text-xs text-blue-400 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  Click to enter local arena
+                <span className="text-sm font-medium text-gray-500">
+                  Currently Not Available
                 </span>
               </div>
             </CardContent>


### PR DESCRIPTION
- Keep Local Duel card visible but unselectable
- Add 'Currently Not Available' label
- Remove click handler and add disabled styling
- Maintain original blue theme but with reduced opacity